### PR TITLE
Added setPasswordAttribute function to User Model

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -36,4 +36,14 @@ class User extends Model implements AuthenticatableContract,
      * @var array
      */
     protected $hidden = ['password', 'remember_token'];
+
+      
+    public function setPasswordAttribute($value)
+    {
+        $this->attributes['password'] = \Hash::make($value);
+    }
+
+
+
+    
 }


### PR DESCRIPTION
Added the Set PassWord Attribute function to User Model.
This pull needed in order to see if Kristie and Jenn can see updated Create Users Table migration.
No expected Conflicts